### PR TITLE
Added setting to disable the automatic inclusion of Stripe Elements JS.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,7 +30,7 @@ class Plugin extends \craft\base\Plugin
     /**
      * @inheritDoc
      */
-    public $schemaVersion = '2.0';
+    public $schemaVersion = '2.1';
 
     // Traits
     // =========================================================================

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -102,6 +102,12 @@ class Gateway extends BaseGateway
      */
     public $signingSecret;
 
+    /**
+     * @var bool
+     */
+    public $includeAssets;
+
+
     // Public methods
     // =========================================================================
 
@@ -145,8 +151,10 @@ class Gateway extends BaseGateway
         $previousMode = $view->getTemplateMode();
         $view->setTemplateMode(View::TEMPLATE_MODE_CP);
 
-        $view->registerJsFile('https://js.stripe.com/v3/');
-        $view->registerAssetBundle(ChargeFormAsset::class);
+        if ($this->includeAssets) {
+            $view->registerJsFile('https://js.stripe.com/v3/');
+            $view->registerAssetBundle(ChargeFormAsset::class);
+        }
 
         $html = $view->renderTemplate('commerce-stripe/paymentForms/chargeForm', $params);
         $view->setTemplateMode($previousMode);

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -67,6 +67,12 @@ class PaymentIntents extends BaseGateway
      */
     public $signingSecret;
 
+    /**
+     * @var bool
+     */
+    public $includeAssets;
+
+    
     // Public methods
     // =========================================================================
 
@@ -110,8 +116,10 @@ class PaymentIntents extends BaseGateway
         $previousMode = $view->getTemplateMode();
         $view->setTemplateMode(View::TEMPLATE_MODE_CP);
 
-        $view->registerJsFile('https://js.stripe.com/v3/');
-        $view->registerAssetBundle(IntentsFormAsset::class);
+        if ($this->includeAssets) {
+            $view->registerJsFile('https://js.stripe.com/v3/');
+            $view->registerAssetBundle(IntentsFormAsset::class);
+        }
 
         $html = $view->renderTemplate('commerce-stripe/paymentForms/intentsForm', $params);
         $view->setTemplateMode($previousMode);

--- a/src/migrations/m190726_134026_include_assets.php
+++ b/src/migrations/m190726_134026_include_assets.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace craft\commerce\stripe\migrations;
+
+use craft\commerce\Plugin as Commerce;
+use craft\commerce\stripe\gateways\Gateway;
+use craft\commerce\stripe\gateways\PaymentIntents;
+use craft\db\Migration;
+
+/**
+ * m190726_134026_include_assets migration.
+ */
+class m190726_134026_include_assets extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        // Place migration code here...
+        $gateways = Commerce::getInstance()->getGateways()->getAllGateways();
+
+        foreach ($gateways as $gateway) {
+            if ($gateway instanceof Gateway || $gateway instanceof PaymentIntents) {
+                $gateway->includeAssets = true;
+                Commerce::getInstance()->getGateways()->saveGateway($gateway);
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m190726_134026_include_assets cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/templates/gatewaySettings/chargeSettings.html
+++ b/src/templates/gatewaySettings/chargeSettings.html
@@ -47,3 +47,11 @@
     on: gateway.sendReceiptEmail,
     errors: gateway.getErrors('sendReceiptEmail'),
 }) }}
+
+{{ lightswitchField({
+    label: "Include Stripe assets?"|t('commerce-stripe'),
+    instructions: "Disable this option to build your own Stripe Elements implementation.",
+    name: 'includeAssets',
+    on: gateway.includeAssets,
+    errors: gateway.getErrors('includeAssets'),
+}) }}

--- a/src/templates/gatewaySettings/intentsSettings.html
+++ b/src/templates/gatewaySettings/intentsSettings.html
@@ -39,3 +39,11 @@
     on: gateway.sendReceiptEmail,
     errors: gateway.getErrors('sendReceiptEmail'),
 }) }}
+
+{{ lightswitchField({
+    label: "Include Stripe assets?"|t('commerce-stripe'),
+    instructions: "Disable this option to build your own Stripe Elements implementation.",
+    name: 'includeAssets',
+    on: gateway.includeAssets,
+    errors: gateway.getErrors('includeAssets'),
+}) }}


### PR DESCRIPTION
I need to build my own custom Stripe Elements implementation but cannot due to the assets being included automatically with no ability to disable them. I've added a new setting to disable the assets on a per-gateway basis. Hopefully it's up to scratch.