### PR TITLE
Fixes missing quote in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ use yii\base\Event;
 
 Event::on(StripeGateway::class, StripeGateway::EVENT_BUILD_GATEWAY_REQUEST, function(BuildGatewayRequestEvent $e) {
   if ($e->transaction->type === 'refund') {
-    $e->request['someKey] = 'some value';
+    $e->request['someKey'] = 'some value';
   }
 });
 ```


### PR DESCRIPTION
This fixes a missing quotation mark in the example.