### PR TITLE
Payment Intent JS issue fix

### DIFF
--- a/src/web/assets/intentsform/js/paymentForm.js
+++ b/src/web/assets/intentsform/js/paymentForm.js
@@ -139,11 +139,11 @@ class PaymentIntentsHandler {
             };
 
             // Tokenize the credit card details and create a payment source
-            this.stripeInstance.createPaymentMethod('card', card, paymentData).then(function(result) {
+            this.stripeInstance.createPaymentMethod('card', card, paymentData).then(result => {
                 if (result.error) {
-                    this.displayMessage('Please wait, processing payment...');
                     $form.data('processing', false);
                 } else {
+                    this.displayMessage('Please wait, processing payment...');
                     // Add the payment source token to the form.
                     $form.append($('<input type="hidden" name="paymentMethodId"/>').val(result.paymentMethod.id));
                     $form.get(0).submit();


### PR DESCRIPTION
This is a fix for the payment intent javascript.
There was a major issue that wouldn't let the form submitted.

The issue was the original script was trying to reference `this.displayMessage()` inside a promise which wasn't using the arrow function and therefor its scope to `this` was not the expected one.

I updated the promise to now use the arrow function e.g. `paymentData).then(result => {...`

The second issue was the login of that promise was to display a message saying "Please wait, processing payment" if there was an error. This meant if the user triggered any kind of error e.g. validation, the only message they would see if the one above.

I've moved the call to `this.displayMessage('Please wait...` to the correct place e.g. when no errors have occurred on submit.