### PR TITLE
Make webhook methods public so we can access them from a module

### DIFF
--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -462,6 +462,33 @@ abstract class SubscriptionGateway extends Gateway
         return $currency ? $invoice->total / (10 ** $currency->minorUnit) : $invoice->total;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function handleWebhook(array $data)
+    {
+        switch ($data['type']) {
+            case 'plan.deleted':
+            case 'plan.updated':
+                $this->handlePlanEvent($data);
+                break;
+            case 'invoice.payment_succeeded':
+                $this->handleInvoiceSucceededEvent($data);
+                break;
+            case 'invoice.created':
+                $this->handleInvoiceCreated($data);
+                break;
+            case 'customer.subscription.deleted':
+                $this->handleSubscriptionExpired($data);
+                break;
+            case 'customer.subscription.updated':
+                $this->handleSubscriptionUpdated($data);
+                break;
+        }
+
+        parent::handleWebhook($data);
+    }
+
     // Protected methods
     // =========================================================================
 
@@ -715,33 +742,4 @@ abstract class SubscriptionGateway extends Gateway
 
         return $invoice;
     }
-
-    /**
-     * @inheritdoc
-     */
-    protected function handleWebhook(array $data)
-    {
-        switch ($data['type']) {
-            case 'plan.deleted':
-            case 'plan.updated':
-                $this->handlePlanEvent($data);
-                break;
-            case 'invoice.payment_succeeded':
-                $this->handleInvoiceSucceededEvent($data);
-                break;
-            case 'invoice.created':
-                $this->handleInvoiceCreated($data);
-                break;
-            case 'customer.subscription.deleted':
-                $this->handleSubscriptionExpired($data);
-                break;
-            case 'customer.subscription.updated':
-                $this->handleSubscriptionUpdated($data);
-                break;
-        }
-
-        parent::handleWebhook($data);
-    }
-
-
 }

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -259,20 +259,19 @@ class Gateway extends BaseGateway
         throw new NotImplementedException('This gateway does not support that functionality');
     }
 
-
-    // Protected methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      */
-    protected function handleWebhook(array $data) {
+    public function handleWebhook(array $data) {
         if (!empty($data['data']['object']['metadata']['three_d_secure_flow'])) {
             $this->handle3DSecureFlowEvent($data);
         }
 
         parent::handleWebhook($data);
     }
+
+    // Protected methods
+    // =========================================================================
 
     /**
      * Handle a 3D Secure related event.

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -398,14 +398,10 @@ class PaymentIntents extends BaseGateway
         return in_array($subscriptionData['status'], ['incomplete', 'past_due', 'unpaid']) && in_array($intentData['status'], ['requires_payment_method', 'requires_confirmation', 'requires_action']);
     }
 
-
-    // Protected methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      */
-    protected function handleWebhook(array $data)
+    public function handleWebhook(array $data)
     {
         switch ($data['type']) {
             case 'invoice.payment_failed':
@@ -415,6 +411,9 @@ class PaymentIntents extends BaseGateway
 
         parent::handleWebhook($data);
     }
+
+    // Protected methods
+    // =========================================================================
 
     /**
      * Handle a failed invoice by updating the subscription data for the subscription it failed.


### PR DESCRIPTION
This will allow us to process the webhook calls through a queue, while awaiting for Commerce to support it natively.