### PR TITLE
Add allowSubscriptionWithoutPaymentMethod setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ For subscriptions with automatic payments, Stripe creates an invoice 1-2 hours b
 
 This setting affect all Stripe gateways on your Commerce installation.
 
+### The `allowSubscriptionWithoutPaymentMethod` setting
+
+Normally, this plugin will not allow a subscription to be created if the customer has no payment methods in Stripe. By setting this to true in your `commerce-stripe.php` config file, a customer can create a subscription without any payment information. This is useful for trial subscription flows where you do not wish to take payment information up front.
+
+This setting affect all Stripe gateways on your Commerce installation.
+
 ## Subscriptions
 
 ### Creating a subscription plan

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -291,7 +291,7 @@ class PaymentIntents extends BaseGateway
         $customer = StripePlugin::getInstance()->getCustomers()->getCustomer($this->id, $user);
         $paymentMethods = PaymentMethod::all(['customer' => $customer->reference, 'type' => 'card']);
 
-        if (\count($paymentMethods->data) === 0) {
+        if (!StripePlugin::getInstance()->getSettings()->allowSubscriptionWithoutPaymentMethod && \count($paymentMethods->data) === 0) {
             throw new PaymentSourceException(Craft::t('commerce-stripe', 'No payment sources are saved to use for subscriptions.'));
         }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -26,4 +26,9 @@ class Settings extends Model
      * @var bool Whether to attempt to charge any created invoice immediately instead of waiting 1-2 hours.
      */
     public $chargeInvoicesImmediately = false;
+
+    /**
+     * @var bool Whether to allow creation of a subscription for customers without any payment methods, useful for trials without taking payment up-front
+     */
+    public $allowSubscriptionWithoutPaymentMethod = false;
 }


### PR DESCRIPTION
The use case is allowing a user to create a trial subscription without having to enter payment information.