### PR TITLE
Add translation filter for On period end option

### DIFF
--- a/src/templates/cancelSubscriptionForm.html
+++ b/src/templates/cancelSubscriptionForm.html
@@ -1,16 +1,16 @@
 {% import "_includes/forms" as forms %}
 
 <fieldset class="cancel-options">
-    <div class="multitext">
-        <div class="multitextrow">
-            {{ forms.selectField({
+	<div class="multitext">
+		<div class="multitextrow">
+			{{ forms.selectField({
                 label: 'Cancel subscription'|t('commerce-stripe'),
                 name: 'cancelImmediately',
                 options: [
                     {label: 'Immediately'|t('commerce-stripe'), value: (subscription.uid~':1')|hash},
-                    {label: 'On period end', value: (subscription.uid~':0')|hash}
+                    {label: 'On period end'|t('commerce-stripe'), value: (subscription.uid~':0')|hash}
                 ]
             }) }}
-        </div>
-    </div>
+		</div>
+	</div>
 </fieldset>


### PR DESCRIPTION
Missing translation filter for "On period end" in cancelSubscriptionForm.html

This is only available on Immediately option.