### PR TITLE
Include changes made to $event->request['metadata'], since $event->metadata is deprecated

### DIFF
--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -366,7 +366,7 @@ abstract class Gateway extends BaseGateway
         $this->trigger(self::EVENT_BUILD_GATEWAY_REQUEST, $event);
 
         $request = array_merge($event->request, $request);
-        $request['metadata'] = array_merge($event->metadata, $metadata);
+        $request['metadata'] = array_merge($event->metadata, $event->request['metadata'], $metadata);
 
         if ($this->sendReceiptEmail) {
             $request['receipt_email'] = $transaction->getOrder()->email;


### PR DESCRIPTION
### Description
The 'BuildGatewayRequestEvent' specifies that $metadata is deprecated, and to use $request['metadata'] instead. However, the code in buildRequestData after the event references $event->metadata, and ignores $event->request['metadata']. $event->request['metadata'] will have gotten overwritten by $request['metadata'] in the line `$request = array_merge($event->request, $request);`

