### PR TITLE
Add plan reference to the SubscriptionRequestEvent

### DIFF
--- a/src/events/SubscriptionRequestEvent.php
+++ b/src/events/SubscriptionRequestEvent.php
@@ -7,6 +7,7 @@
 
 namespace craft\commerce\stripe\events;
 
+use craft\commerce\base\Plan;
 use yii\base\Event;
 
 /**
@@ -19,6 +20,11 @@ class SubscriptionRequestEvent extends Event
 {
     // Properties
     // =========================================================================
+
+    /**
+     * @var Plan The subscription plan
+     */
+    public $plan;
 
     /**
      * @var array The subscription parameters

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -320,6 +320,7 @@ class PaymentIntents extends BaseGateway
         $subscriptionParameters['expand'] = ['latest_invoice.payment_intent'];
 
         $event = new SubscriptionRequestEvent([
+            'plan' => $plan,
             'parameters' => $subscriptionParameters
         ]);
 


### PR DESCRIPTION
### Description

This PR adds the subscription Plan to the `SubscriptionRequestEvent`. I think that it would add some longevity to code which uses this event because you wouldn't need to rely on the Stripe-specific parameters to fetch the subscription plan, instead you'd have direct access to it via the event object. For user's who are fetching the plan, this should also remove an extra DB lookup:

```diff
Event::on(
    StripeGateway::class,
    StripeGateway::EVENT_BEFORE_SUBSCRIBE,
    function(SubscriptionRequestEvent $event) {
-       $planReference = $event->parameters['items'][0]['plan'];
-       $plan = \craft\commerce\Plugin::getInstance()->plans->getPlanByReference($planReference);
+       $plan = $event->plan;        
        // ...
    }
);
```

