### PR TITLE
Fixed #147

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,7 +28,7 @@ class Plugin extends \craft\base\Plugin
     /**
      * @inheritDoc
      */
-    public $schemaVersion = '2.2.0';
+    public $schemaVersion = '2.4.0';
 
     use Services;
 

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -502,7 +502,7 @@ class PaymentIntents extends BaseGateway
         try {
             // If this is a customer that's logged in, attempt to continue the timeline
             if ($customer) {
-                $paymentIntent = $paymentIntentService->getPaymentIntent($this->id, $transaction->orderId, $customer->id);
+                $paymentIntent = $paymentIntentService->getPaymentIntent($this->id, $transaction->orderId, $customer->id, $transaction->hash);
             }
 
             // If a payment intent exists, update that.
@@ -518,6 +518,7 @@ class PaymentIntents extends BaseGateway
                 if ($customer) {
                     $paymentIntent = new PaymentIntentModel([
                         'orderId' => $transaction->orderId,
+                        'transactionHash' => $transaction->hash,
                         'customerId' => $customer->id,
                         'gatewayId' => $this->id,
                         'reference' => $stripePaymentIntent->id,

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -57,6 +57,7 @@ class Install extends Migration
             'gatewayId' => $this->integer()->notNull(),
             'customerId' => $this->integer()->notNull(),
             'orderId' => $this->integer()->notNull(),
+            'transactionHash' => $this->string(),
             'intentData' => $this->text(),
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),

--- a/src/migrations/m210903_040320_payment_intent_unique_on_transaction.php
+++ b/src/migrations/m210903_040320_payment_intent_unique_on_transaction.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace craft\commerce\stripe\migrations;
+
+use Craft;
+use craft\commerce\stripe\gateways\PaymentIntents;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\helpers\MigrationHelper;
+use yii\db\Expression;
+
+/**
+ * m210903_040320_payment_intent_unique_on_transaction migration.
+ */
+class m210903_040320_payment_intent_unique_on_transaction extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        if (!$this->db->columnExists('{{%stripe_paymentintents}}', 'transactionHash')) {
+            $this->addColumn('{{%stripe_paymentintents}}', 'transactionHash', $this->string()->after('orderId'));
+        }
+
+        MigrationHelper::dropAllIndexesOnTable('{{%stripe_paymentintents}}', $this);
+
+        $gatewayTypes = (new Query())
+            ->select(['id', 'type'])
+            ->from(['{{%commerce_gateways}}'])
+            ->pairs();
+
+        $gatewayIds = [];
+        foreach ($gatewayTypes as $id => $gatewayType) {
+            if (is_a(PaymentIntents::class, $gatewayType, true)) {
+                $gatewayIds[] = $id;
+            }
+        }
+
+        $transactions = (new Query())
+            ->select(['reference', 'hash'])
+            ->from(['{{%commerce_transactions}}'])
+            ->where(['LIKE', 'reference', 'pi_%', false]) // they are using a payment intent identifier
+            ->andWhere(['gatewayId' => $gatewayIds])
+            ->all();
+
+        foreach ($transactions as $transaction) {
+            $this->update('{{%stripe_paymentintents}}', ['transactionHash' => $transaction['hash']], ['reference' => $transaction['reference']]);
+        }
+
+        $this->createIndex(null, '{{%stripe_paymentintents}}', 'reference', true);
+        $this->createIndex(null, '{{%stripe_paymentintents}}', ['orderId', 'gatewayId', 'customerId', 'transactionHash'], true);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m210903_040320_payment_intent_unique_on_transaction cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/PaymentIntent.php
+++ b/src/models/PaymentIntent.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\commerce\base\GatewayInterface;
 use craft\commerce\base\Model;
 use craft\commerce\elements\Order;
+use craft\commerce\models\Transaction;
 use craft\commerce\Plugin as Commerce;
 use craft\commerce\stripe\Plugin as StripePlugin;
 use craft\commerce\stripe\records\Customer as CustomerRecord;
@@ -48,6 +49,11 @@ class PaymentIntent extends Model
     public $orderId;
 
     /**
+     * @var string The Transaction Hash.
+     */
+    public $transactionHash;
+
+    /**
      * @var string Reference
      */
     public $reference;
@@ -78,6 +84,11 @@ class PaymentIntent extends Model
     private $_order;
 
     /**
+     * @var Transaction|null
+     */
+    private $_transaction;
+
+    /**
      * Returns the customer identifier
      *
      * @return string
@@ -88,7 +99,7 @@ class PaymentIntent extends Model
     }
 
     /**
-     * Returns the user element associated with this customer.
+     * Returns the user element associated with this this payment intent.
      *
      * @return User|null
      */
@@ -105,7 +116,7 @@ class PaymentIntent extends Model
     }
 
     /**
-     * Returns the gateway associated with this customer.
+     * Returns the gateway associated with this this payment intent.
      *
      * @return GatewayInterface|null
      */
@@ -119,7 +130,7 @@ class PaymentIntent extends Model
     }
 
     /**
-     * Returns the user element associated with this customer.
+     * Returns the user customer associated with this payment intent.
      *
      * @return Customer|null
      */
@@ -133,7 +144,7 @@ class PaymentIntent extends Model
     }
 
     /**
-     * Returns the gateway associated with this customer.
+     * Returns the gateway associated with this payment intent.
      *
      * @return Order|null
      */
@@ -147,13 +158,27 @@ class PaymentIntent extends Model
     }
 
     /**
+     * Returns the transation associated with this payment intent.
+     *
+     * @return Order|null
+     */
+    public function getTransaction()
+    {
+        if (null === $this->_tranasction) {
+            $this->_transaction = Commerce::getInstance()->getTransactions()->getTransactionByHash($this->transactionHash);
+        }
+
+        return $this->_transaction;
+    }
+
+    /**
      * @inheritdoc
      */
     public function rules()
     {
         return [
             [['reference'], 'unique', 'targetAttribute' => ['gatewayId', 'reference'], 'targetClass' => CustomerRecord::class],
-            [['gatewayId', 'customerId', 'reference', 'intentData', 'orderId'], 'required'],
+            [['gatewayId', 'customerId', 'reference', 'intentData', 'orderId', 'transactionHash'], 'required'],
         ];
     }
 }

--- a/src/records/PaymentIntent.php
+++ b/src/records/PaymentIntent.php
@@ -19,6 +19,7 @@ use yii\db\ActiveQueryInterface;
  * @property int $customerId
  * @property int $gatewayId
  * @property int $orderId
+ * @property string $transactionHash
  * @property string $reference
  * @property string $intentData
  * @property Gateway $gateway

--- a/src/services/PaymentIntents.php
+++ b/src/services/PaymentIntents.php
@@ -29,11 +29,21 @@ class PaymentIntents extends Component
      *
      * @return PaymentIntent|null
      */
-    public function getPaymentIntent(int $gatewayId, $orderId, $customerId)
+    public function getPaymentIntent(int $gatewayId, $orderId, $customerId, $transactionHash = null)
     {
-        $result = $this->_createIntentQuery()
-            ->where(['orderId' => $orderId, 'gatewayId' => $gatewayId, 'customerId' => $customerId])
-            ->one();
+        // The `orderId` is not unique across multiple payments (the new partial payment feature) on the same order.
+        // We have added `transactionHash` in commerce-stripe 2.4 to solve this.
+        // TODO make transactionHash required in next major release. Could also drop `orderId`
+        if ($transactionHash) {
+            $result = $this->_createIntentQuery()
+                ->where(['orderId' => $orderId, 'gatewayId' => $gatewayId, 'customerId' => $customerId, 'transactionHash' => $transactionHash])
+                ->one();
+        } else {
+            // This is just in case 3rd party code is calling this method.
+            $result = $this->_createIntentQuery()
+                ->where(['orderId' => $orderId, 'gatewayId' => $gatewayId, 'customerId' => $customerId, 'transactionHash' => null])
+                ->one();
+        }
 
         if ($result !== null) {
             return new PaymentIntent($result);
@@ -86,6 +96,7 @@ class PaymentIntents extends Component
         $record->gatewayId = $paymentIntent->gatewayId;
         $record->customerId = $paymentIntent->customerId;
         $record->orderId = $paymentIntent->orderId;
+        $record->transactionHash = $paymentIntent->transactionHash;
         $record->intentData = $paymentIntent->intentData;
 
         $paymentIntent->validate();
@@ -117,6 +128,7 @@ class PaymentIntents extends Component
                 'customerId',
                 'reference',
                 'orderId',
+                'transactionHash',
                 'intentData',
             ])
             ->from(['{{%stripe_paymentintents}}']);


### PR DESCRIPTION
- Adds `transactionHash` to payment intents table.
- This ensures that the payment intent is unique to the transaction.
- Error was due to trying to resume a previous payment intent, but a new partial payment should be a new transaction, not related to the last payment on the same order.

### Description



### Related issues

