### PR TITLE
add quantity parameter in SwitchPlan model, and send info to Stipe in…

### DIFF
--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -427,6 +427,10 @@ abstract class SubscriptionGateway extends Gateway
             $stripeSubscription->billing_cycle_anchor = $parameters->billingCycleAnchor;
         }
 
+        if ($parameters->quantity) {
+            $stripeSubscription->items[0]['quantity'] = $parameters->quantity;
+        }
+
         if ($parameters->prorationDate) {
             /** @phpstan-ignore-next-line */
             $stripeSubscription->proration_date = $parameters->prorationDate;

--- a/src/models/forms/SwitchPlans.php
+++ b/src/models/forms/SwitchPlans.php
@@ -38,4 +38,9 @@ class SwitchPlans extends SwitchPlansForm
      * @var int Timestamp on which to base the proration calculation
      */
     public $prorationDate;
+
+    /**
+     * @var int Quantity of subscription
+     */
+    public $quantity;
 }


### PR DESCRIPTION
… SubscriptionGateway switchSubscriptionPlan

### Description

StripeSubscriptionPlan can have a quantity at creation, but the function to SwitchSubscriptionPlan doesn't take quantity into account, so customer with 3 ongoing monthly subscription switching to yearly ends with only 1 yearly subscription, not 3. 

This fixes the issue and allow to switch the right quantity of subscription plans.

### Related issues

