### PR TITLE
Added EVENT_BEFORE_CREATE_CUSTOMER hook

### DIFF
--- a/src/events/CreateCustomerEvent.php
+++ b/src/events/CreateCustomerEvent.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\commerce\stripe\events;
+
+use craft\elements\User;
+use yii\base\Event;
+
+/**
+ * Class CreateCustomerEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 1.0
+ */
+class CreateCustomerEvent extends Event
+{
+    /**
+     * @var array The customer data passsed to Stripe
+     * refer to stripe docs for available fields - https://stripe.com/docs/api/customers/object
+     */
+    public $customer;
+
+    /**
+     * @var User The currently logged in Craft user
+     */
+    public $user;
+}

--- a/src/services/Customers.php
+++ b/src/services/Customers.php
@@ -32,6 +32,25 @@ use yii\base\Exception;
 class Customers extends Component
 {
     /**
+     * @event CreateCustomerEvent The event that is triggered before a new customer is saved in the gateway.
+     *
+     * Plugins can get notified whenever a new customer is being saved.
+     *
+     * ```php
+     * use craft\commerce\stripe\events\CreateCustomerEvent;
+     * use craft\commerce\stripe\services\Customers;
+     * use yii\base\Event;
+     *
+     * Event::on(Customers::class, Customers::EVENT_BEFORE_CREATE_CUSTOMER, function(CreateCustomerEvent $e) {
+     *     $e->customer['someKey'] = 'some value';
+     *     unset($e->customer['unneededKey']);
+     * });
+     * ```
+     */
+    const EVENT_BEFORE_CREATE_CUSTOMER = 'beforeCreateCustomer';
+
+
+    /**
      * Returns a customer by gateway and user
      *
      * @param int $gatewayId The stripe gateway
@@ -56,10 +75,19 @@ class Customers extends Component
         Stripe::setAppInfo(StripePlugin::getInstance()->name, StripePlugin::getInstance()->version, StripePlugin::getInstance()->documentationUrl);
         Stripe::setApiVersion(SubscriptionGateway::STRIPE_API_VERSION);
 
-        $stripeCustomer = StripeCustomer::create([
+        $customerData = [
             'description' => Craft::t('commerce-stripe', 'Customer for Craft user with ID {id}', ['id' => $user->id]),
             'email' => $user->email,
+        ];
+
+        $event = new CreateCustomerEvent([
+            'customer' => $customerData,
+            'user' => $user
         ]);
+
+        $this->trigger(self::EVENT_BEFORE_CREATE_CUSTOMER, $event);
+
+        $stripeCustomer = StripeCustomer::create($event->customer);
 
         $customer = new Customer([
             'userId' => $user->id,


### PR DESCRIPTION
### Description
This allows for additional customer data to be added to the customer record prior to being created in Stripe for the first time.


### Related issues
https://github.com/craftcms/commerce-stripe/issues/198
