### PR TITLE
Adds new beforeConfirmPaymentIntent event

### DIFF
--- a/src/events/PaymentIntentConfirmationEvent.php
+++ b/src/events/PaymentIntentConfirmationEvent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\commerce\stripe\events;
+
+use yii\base\Event;
+
+/**
+ * Class PaymentIntentConfirmationEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.4.4
+ */
+class PaymentIntentConfirmationEvent extends Event
+{
+    /**
+     * @var array The parameters passed to the PaymentIntent.
+     */
+    public $parameters;
+}

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -42,6 +42,7 @@ use Stripe\Refund;
 use Stripe\Subscription as StripeSubscription;
 use Throwable;
 use yii\base\NotSupportedException;
+use craft\commerce\stripe\events\PaymentIntentConfirmationEvent;
 use function count;
 
 /**
@@ -71,6 +72,11 @@ class PaymentIntents extends BaseGateway
      * @var string
      */
     public $signingSecret;
+
+    /**
+     * @event BeforeConfirmPaymentIntent The event that is triggered before a PaymentIntent is confirmed
+     */
+    const EVENT_BEFORE_CONFIRM_PAYMENT_INTENT = 'beforeConfirmPaymentIntent';
 
     /**
      * @inheritdoc
@@ -569,9 +575,18 @@ class PaymentIntents extends BaseGateway
     private function _confirmPaymentIntent(PaymentIntent $stripePaymentIntent, Transaction $transaction)
     {
         $this->configureStripeClient();
-        $stripePaymentIntent->confirm([
+
+        $parameters = [
             'return_url' => UrlHelper::actionUrl('commerce/payments/complete-payment', ['commerceTransactionId' => $transaction->id, 'commerceTransactionHash' => $transaction->hash]),
+        ];
+
+        $event = new PaymentIntentConfirmationEvent([
+            'parameters' => $parameters
         ]);
+
+        $this->trigger(self::EVENT_BEFORE_CONFIRM_PAYMENT_INTENT, $event);
+
+        $stripePaymentIntent->confirm($event->parameters);
     }
 
     /**


### PR DESCRIPTION
### Description
@lukeholder this is the suggested change to add an event that allows addition of parameters for MOTO transactions via the PaymentIntents API.

Would appreciate it if this could be reviewed and merged in so we can use this. Apologies if this PR isn't as you'd like it, I've not contributed directly before.