### PR TITLE
Fixed a bug where switching subscription plan throws a $billingCycleAnchor type property initialization error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release Notes for Stripe for Craft Commerce
 
+## Unreleased
 
 ### Fixed
-- Fixed a bug where switching subscription plan throws a $billingCycleAnchor type property initialization error. ([#3035](https://github.com/craftcms/commerce/issues/3035))
+- Fixed a PHP error when switching a subscription’s plan. ([#3035](https://github.com/craftcms/commerce/issues/3035))
 
 ## 3.0.2 - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe for Craft Commerce
 
+
+### Fixed
+- Fixed a bug where switching subscription plan throws a $billingCycleAnchor type property initialization error. ([#3035](https://github.com/craftcms/commerce/issues/3035))
+
 ## 3.0.2 - 2022-11-17
 
 ### Added

--- a/src/models/forms/SwitchPlans.php
+++ b/src/models/forms/SwitchPlans.php
@@ -30,9 +30,9 @@ class SwitchPlans extends SwitchPlansForm
     public bool $billImmediately = false;
 
     /**
-     * @var string|int The billing cycle anchor. Can be set to `now` or `unchanged` (default).
+     * @var string|int|null The billing cycle anchor. Can be set to `now` or `unchanged` (default).
      */
-    public string|int $billingCycleAnchor;
+    public string|int|null $billingCycleAnchor = null;
 
     /**
      * @var int|null Timestamp on which to base the proration calculation


### PR DESCRIPTION
Fixed https://github.com/craftcms/commerce/issues/3035