### PR TITLE
Added functionality to trigger an event before creating the Stripe cu…

### DIFF
--- a/src/events/CreateCustomerEvent.php
+++ b/src/events/CreateCustomerEvent.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\commerce\stripe\events;
+
+use craft\elements\User;
+use yii\base\Event;
+
+/**
+ * Class CreateCustomerEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 1.0
+ */
+class CreateCustomerEvent extends Event
+{
+    /**
+     * @var array The customer data passsed to Stripe
+     * refer to stripe docs for available fields - https://stripe.com/docs/api/customers/object
+     */
+    public $customer;
+
+    /**
+     * @var User The currently logged in Craft user
+     */
+    public $user;
+}


### PR DESCRIPTION
Update to a previous / stale PR **(https://github.com/craftcms/commerce-stripe/pull/215)**. This one should pass code standards tests.

### Description

This PR adds an new event before new customer account data is added to Stripe for the first time.

Allows devs the ability to pass more useful customer information into the Stripe API aside from the current "Craft User + UserID".

### Related issues

https://github.com/craftcms/commerce-stripe/issues/198
