### PR TITLE
Update support for direct debit payment methods and sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Stripe for Craft Commerce now requires Commerce 4.3.3 or later.
 - It is now possible to create SEPA and Bacs Direct Debit payment sources.
 - Fixed a bug where it wasn’t possible to pay using the SEPA Direct Debit payment method. ([#265](https://github.com/craftcms/commerce/issues/265))
 - Added `craft\commerce\stripe\SubscriptionGateway::handlePaymentIntentSucceeded`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Stripe for Craft Commerce
 
+## Unreleased
+
+- It is now possible to create SEPA and Bacs Direct Debit payment sources.
+- Fixed a bug where it wasn’t possible to pay using the SEPA Direct Debit payment method. ([#265](https://github.com/craftcms/commerce/issues/265))
+- Added `craft\commerce\stripe\SubscriptionGateway::handlePaymentIntentSucceeded`.
+
 ## 4.0.1.1 - 2023-10-25
 
 - Restored support for backend payments using the old payment form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fixed a bug where it wasn’t possible to pay using the SEPA Direct Debit payment method. ([#265](https://github.com/craftcms/commerce/issues/265))
 - Fixed a bug where failed PayPal payments would cause infinite redirects. ([#266](https://github.com/craftcms/commerce-stripe/issues/266))
 - Fixed a bug where JavaScript files were being served incorrectly. ([#270](https://github.com/craftcms/commerce-stripe/issues/270))
-- Added `craft\commerce\stripe\SubscriptionGateway::handlePaymentIntentSucceeded`.
+- Added `craft\commerce\stripe\SubscriptionGateway::handlePaymentIntentSucceeded()`.
 
 ## 4.0.1.1 - 2023-10-25
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "php": "^8.0.2",
     "craftcms/cms": "^4.0.0",
     "stripe/stripe-php": "^10.0",
-    "craftcms/commerce": "^4.3"
+    "craftcms/commerce": "^4.3.3"
   },
   "require-dev": {
     "craftcms/phpstan": "dev-main",

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -32,7 +32,6 @@ use craft\commerce\stripe\models\Plan;
 use craft\commerce\stripe\Plugin as StripePlugin;
 use craft\commerce\stripe\responses\SubscriptionResponse;
 use craft\errors\ElementNotFoundException;
-use craft\helpers\ArrayHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Json;
 use craft\web\View;

--- a/src/responses/PaymentIntentResponse.php
+++ b/src/responses/PaymentIntentResponse.php
@@ -59,6 +59,10 @@ class PaymentIntentResponse implements RequestResponseInterface
             }
         }
 
+        if ((!array_key_exists('next_action', $this->data) || $this->data['next_action'] === null) && array_key_exists('status', $this->data) && $this->data['status'] === 'processing') {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
### Description
When using the Stripe elements form it is not possible to pay for an order with direct debit payment methods

It is also not currently possible to save direct debit payment methods and have them sync'd into Commerce.


### Related issues
#265 