### PR TITLE
WIP fix for address information in payment element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for Stripe for Craft Commerce
 
+## Unreleased
+
+- Restored support for backend payments using the old payment form.
+- Fixed missing icon.
+
 ## 4.0.1 - 2023-09-28
+
 - Fixed a PHP error that occurred when switching a subscription’s plan.
 
 ## 4.0.0 - 2023-09-13

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -171,14 +171,13 @@ class PaymentIntents extends BaseGateway
                 'postal_code' => $order->getBillingAddress()->postalCode ?? '',
                 'state' => $order->getBillingAddress()->getAdministrativeArea() ?? '',
             ];
-            $billingDetails = [
-                'name' => $order->getBillingAddress()->fullName ?? '',
-                'email' => $order->email,
-                'address' => $defaultBillingAddressValues,
-            ];
 
             $defaults['elementOptions']['defaultValues'] = [
-                'billingDetails' => $billingDetails,
+                'billingDetails' => [
+                    'name' => $order->getBillingAddress()->fullName ?? '',
+                    'email' => $order->email,
+                    'address' => $defaultBillingAddressValues,
+                ],
             ];
         }
 

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -142,7 +142,7 @@ class PaymentIntents extends BaseGateway
         $order = $params['order'] ?? null;
         $billingDetails = null;
         $businessDetails = null;
-        if($order && $order->getBillingAddress()) {
+        if ($order && $order->getBillingAddress()) {
             $defaultBillingAddressValues = [
                 'country' => $order->getBillingAddress()->getCountryCode() ?: '',
                 'line1' => $order->getBillingAddress()->addressLine1 ?? '',
@@ -156,7 +156,7 @@ class PaymentIntents extends BaseGateway
                     'email' => $order->email,
                     'address' => $defaultBillingAddressValues,
             ];
-            if($order->getBillingAddress()->organization) {
+            if ($order->getBillingAddress()->organization) {
                 $businessDetails = [
                     'name' => $order->getBillingAddress()->organization,
                 ];
@@ -186,11 +186,10 @@ class PaymentIntents extends BaseGateway
 
         ];
 
-        if($billingDetails) {
+        if ($billingDetails) {
             $defaults['elementOptions']['defaultValues']['billingDetails'] = $billingDetails;
         }
-        if($businessDetails)
-        {
+        if ($businessDetails) {
             $defaults['elementOptions']['defaultValues']['businessDetails'] = $businessDetails;
         }
 

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -12,6 +12,7 @@ use craft\commerce\base\Plan as BasePlan;
 use craft\commerce\base\RequestResponseInterface;
 use craft\commerce\base\SubscriptionResponseInterface;
 use craft\commerce\behaviors\CustomerBehavior;
+use craft\commerce\elements\Order;
 use craft\commerce\elements\Subscription;
 use craft\commerce\errors\PaymentSourceCreatedLaterException;
 use craft\commerce\errors\SubscriptionException;
@@ -34,6 +35,7 @@ use craft\commerce\stripe\responses\PaymentIntentResponse;
 use craft\commerce\stripe\web\assets\elementsform\ElementsFormAsset;
 use craft\commerce\stripe\web\assets\intentsform\IntentsFormAsset;
 use craft\elements\User;
+use craft\helpers\ArrayHelper;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
@@ -136,6 +138,31 @@ class PaymentIntents extends BaseGateway
      */
     public function getPaymentFormHtml(array $params): ?string
     {
+        /** @var ?Order $order */
+        $order = $params['order'] ?? null;
+        $billingDetails = null;
+        $businessDetails = null;
+        if($order && $order->getBillingAddress()) {
+            $defaultBillingAddressValues = [
+                'country' => $order->getBillingAddress()->getCountryCode() ?: '',
+                'line1' => $order->getBillingAddress()->addressLine1 ?? '',
+                'line2' => $order->getBillingAddress()->addressLine2 ?? '',
+                'city' => $order->getBillingAddress()->locality ?? '',
+                'postal_code' => $order->getBillingAddress()->postalCode ?? '',
+                'state' => $order->getBillingAddress()->getAdministrativeArea() ?? '',
+            ];
+            $billingDetails = [
+                    'name' => $order->getBillingAddress()->fullName ?? '',
+                    'email' => $order->email,
+                    'address' => $defaultBillingAddressValues,
+            ];
+            if($order->getBillingAddress()->organization) {
+                $businessDetails = [
+                    'name' => $order->getBillingAddress()->organization,
+                ];
+            }
+        }
+
         $defaults = [
             'clientSecret' => '',
             'scenario' => 'payment',
@@ -149,15 +176,25 @@ class PaymentIntents extends BaseGateway
                 'layout' => [
                     'type' => 'tabs',
                 ],
+                'defaultValues' => [],
             ],
             'submitButtonClasses' => '',
             'errorMessageClasses' => '',
             'submitButtonText' => Craft::t('commerce', 'Pay'),
             'processingButtonText' => Craft::t('commerce', 'Processing…'),
             'paymentFormType' => self::PAYMENT_FORM_TYPE_ELEMENTS,
+
         ];
 
-        $params = array_merge($defaults, $params);
+        if($billingDetails) {
+            $defaults['elementOptions']['defaultValues']['billingDetails'] = $billingDetails;
+        }
+        if($businessDetails)
+        {
+            $defaults['elementOptions']['defaultValues']['businessDetails'] = $businessDetails;
+        }
+
+        $params = ArrayHelper::merge($defaults, $params);
 
         if ($params['scenario'] == '') {
             return Craft::t('commerce-stripe', 'Commerce Stripe 4.0+ requires a scenario is set on the payment form.');
@@ -446,6 +483,8 @@ class PaymentIntents extends BaseGateway
      */
     public function createPaymentIntent(Transaction $transaction, int $amount, array $metadata, bool $capture, PaymentIntentForm $form): PaymentIntent
     {
+        $order = $transaction->getOrder();
+
         // Base information for the payment intent
         $paymentIntentData = [
             'amount' => $amount,

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -480,8 +480,6 @@ class PaymentIntents extends BaseGateway
      */
     public function createPaymentIntent(Transaction $transaction, int $amount, array $metadata, bool $capture, PaymentIntentForm $form): PaymentIntent
     {
-        $order = $transaction->getOrder();
-
         // Base information for the payment intent
         $paymentIntentData = [
             'amount' => $amount,

--- a/src/web/assets/intentsform/js/paymentForm.js
+++ b/src/web/assets/intentsform/js/paymentForm.js
@@ -1,193 +1,193 @@
 function PaymentIntents(publishableKey, container) {
-    this.container = container;
-    this.stripeInstance = Stripe(publishableKey);
-    this.paymentFormNamespace = this.container.data('payment-form-namespace');
+  this.container = container;
+  this.stripeInstance = Stripe(publishableKey);
+  this.paymentFormNamespace = this.container.data('payment-form-namespace');
 
-    this.perform3dsAuthentication = function (card) {
-        this.displayMessage('Please wait, processing payment...');
-        this.stripeInstance
-            .handleCardPayment(this.container.data('client-secret'), card)
-            .then(
-                function (result) {
-                    if (result.error) {
-                        this.displayMessage(result.error.message);
-                        this.displayPaymentForm();
-                    } else {
-                        location.reload();
-                    }
-                }.bind(this)
-            );
+  this.perform3dsAuthentication = function (card) {
+    this.displayMessage('Please wait, processing payment...');
+    this.stripeInstance
+      .handleCardPayment(this.container.data('client-secret'), card)
+      .then(
+        function (result) {
+          if (result.error) {
+            this.displayMessage(result.error.message);
+            this.displayPaymentForm();
+          } else {
+            location.reload();
+          }
+        }.bind(this)
+      );
+  };
+
+  this.displayStripeMessage = function (event) {
+    if (event.error) {
+      this.displayMessage(event.error.message);
+    } else {
+      this.displayMessage('');
+    }
+  };
+
+  this.displayMessage = function (message) {
+    var messageContainer = $('.card-errors', this.container).get(0);
+    messageContainer.textContent = message;
+
+    if ($('.modal').data('modal')) {
+      $('.modal').data('modal').updateSizeAndPosition();
+    }
+  };
+
+  this.displayPaymentForm = function () {
+    $('.payment-form-fields').removeClass('hidden');
+
+    var elements = this.stripeInstance.elements();
+
+    var style = {
+      base: {
+        // Add your base input styles here. For example:
+        fontSize: '16px',
+        lineHeight: '21px',
+      },
     };
 
-    this.displayStripeMessage = function (event) {
-        if (event.error) {
-            this.displayMessage(event.error.message);
-        } else {
-            this.displayMessage('');
+    // Create an instance of the card Element
+    var card = elements.create('card', {
+      style: style,
+      hidePostalCode: true,
+    });
+
+    card.addEventListener('change', this.displayStripeMessage.bind(this));
+
+    // Add an instance of the card Element into the `card-element` <div>
+    card.mount($('.card-data', this.container).empty().get(0));
+
+    var $form = $('form', this.container);
+
+    if ($form.length === 0) {
+      $form = this.container.parents('form');
+    }
+
+    // Remove already bound events
+    $form.off('submit');
+    $form.data('processing', false);
+
+    $form.on(
+      'submit',
+      function (ev) {
+        ev.preventDefault();
+
+        // If form submitted already, disregard.
+        if ($form.data('processing')) {
+          return false;
         }
-    };
 
-    this.displayMessage = function (message) {
-        var messageContainer = $('.card-errors', this.container).get(0);
-        messageContainer.textContent = message;
+        $form.data('processing', true);
 
-        if ($('.modal').data('modal')) {
-            $('.modal').data('modal').updateSizeAndPosition();
+        // Compose card holder info
+        var cardHolderName, orderEmail, ownerAddress;
+
+        if (
+          $('.card-holder-first-name', $form).length > 0 &&
+          $('.card-holder-last-name', $form).length > 0
+        ) {
+          cardHolderName =
+            $('.card-holder-first-name', $form).val() +
+            ' ' +
+            $('.card-holder-last-name', $form).val();
         }
-    };
 
-    this.displayPaymentForm = function () {
-        $('.payment-form-fields').removeClass('hidden');
+        if ($('.stripe-address', $form).length > 0) {
+          ownerAddress = {
+            line1: $(
+              `input[name="${this.paymentFormNamespace}[stripe-line1]"]`,
+              $form
+            ).val(),
+            city: $(
+              `input[name="${this.paymentFormNamespace}[stripe-city]"]`,
+              $form
+            ).val(),
+            postal_code: $(
+              `input[name="${this.paymentFormNamespace}[stripe-postal-code]"]`,
+              $form
+            ).val(),
+            country: $(
+              `input[name="${this.paymentFormNamespace}[stripe-country]"]`,
+              $form
+            ).val(),
+            state: $(
+              `input[name="${this.paymentFormNamespace}[stripe-state]"]`,
+              $form
+            ).val(),
+          };
+        }
 
-        var elements = this.stripeInstance.elements();
+        // If client secret is present, that's a pretty good indicator that things should be handled on page.
+        if (this.container.data('client-secret')) {
+          this.perform3dsAuthentication(card);
 
-        var style = {
-            base: {
-                // Add your base input styles here. For example:
-                fontSize: '16px',
-                lineHeight: '21px',
-            },
+          return;
+        }
+
+        // This section is for handling things on server end
+        orderEmail = $('input[name=orderEmail]').val();
+        var paymentData = {
+          billing_details: {
+            name: cardHolderName,
+            email: orderEmail,
+            address: ownerAddress,
+          },
         };
 
-        // Create an instance of the card Element
-        var card = elements.create('card', {
-            style: style,
-            hidePostalCode: true,
-        });
-
-        card.addEventListener('change', this.displayStripeMessage.bind(this));
-
-        // Add an instance of the card Element into the `card-element` <div>
-        card.mount($('.card-data', this.container).empty().get(0));
-
-        var $form = $('form', this.container);
-
-        if ($form.length === 0) {
-            $form = this.container.parents('form');
-        }
-
-        // Remove already bound events
-        $form.off('submit');
-        $form.data('processing', false);
-
-        $form.on(
-            'submit',
-            function (ev) {
-                ev.preventDefault();
-
-                // If form submitted already, disregard.
-                if ($form.data('processing')) {
-                    return false;
-                }
-
-                $form.data('processing', true);
-
-                // Compose card holder info
-                var cardHolderName, orderEmail, ownerAddress;
-
-                if (
-                    $('.card-holder-first-name', $form).length > 0 &&
-                    $('.card-holder-last-name', $form).length > 0
-                ) {
-                    cardHolderName =
-                        $('.card-holder-first-name', $form).val() +
-                        ' ' +
-                        $('.card-holder-last-name', $form).val();
-                }
-
-                if ($('.stripe-address', $form).length > 0) {
-                    ownerAddress = {
-                        line1: $(
-                            `input[name="${this.paymentFormNamespace}[stripe-line1]"]`,
-                            $form
-                        ).val(),
-                        city: $(
-                            `input[name="${this.paymentFormNamespace}[stripe-city]"]`,
-                            $form
-                        ).val(),
-                        postal_code: $(
-                            `input[name="${this.paymentFormNamespace}[stripe-postal-code]"]`,
-                            $form
-                        ).val(),
-                        country: $(
-                            `input[name="${this.paymentFormNamespace}[stripe-country]"]`,
-                            $form
-                        ).val(),
-                        state: $(
-                            `input[name="${this.paymentFormNamespace}[stripe-state]"]`,
-                            $form
-                        ).val(),
-                    };
-                }
-
-                // If client secret is present, that's a pretty good indicator that things should be handled on page.
-                if (this.container.data('client-secret')) {
-                    this.perform3dsAuthentication(card);
-
-                    return;
-                }
-
-                // This section is for handling things on server end
-                orderEmail = $('input[name=orderEmail]').val();
-                var paymentData = {
-                    billing_details: {
-                        name: cardHolderName,
-                        email: orderEmail,
-                        address: ownerAddress,
-                    },
-                };
-
-                // Tokenize the credit card details and create a payment source
-                this.stripeInstance.createPaymentMethod('card', card, paymentData).then(
-                    function (result) {
-                        if (result.error) {
-                            this.displayMessage(result.error.message);
-                            $form.data('processing', false);
-                        } else {
-                            // Add the payment source token to the form.
-                            $form.append(
-                                $(
-                                    '<input type="hidden" name="' +
-                                    this.container.data('payment-form-namespace') +
-                                    '[paymentMethodId]"/>'
-                                ).val(result.paymentMethod.id)
-                            );
-                            $form.get(0).submit();
-                        }
-                    }.bind(this)
-                );
-            }.bind(this)
+        // Tokenize the credit card details and create a payment source
+        this.stripeInstance.createPaymentMethod('card', card, paymentData).then(
+          function (result) {
+            if (result.error) {
+              this.displayMessage(result.error.message);
+              $form.data('processing', false);
+            } else {
+              // Add the payment source token to the form.
+              $form.append(
+                $(
+                  '<input type="hidden" name="' +
+                    this.container.data('payment-form-namespace') +
+                    '[paymentMethodId]"/>'
+                ).val(result.paymentMethod.id)
+              );
+              $form.get(0).submit();
+            }
+          }.bind(this)
         );
+      }.bind(this)
+    );
 
-        if ($('.modal').data('modal')) {
-            $('.modal').data('modal').updateSizeAndPosition();
-        }
-    };
+    if ($('.modal').data('modal')) {
+      $('.modal').data('modal').updateSizeAndPosition();
+    }
+  };
 }
 
 function initStripe() {
-    // Because this might get executed before Stripe is loaded.
-    if (typeof Stripe === 'undefined') {
-        setTimeout(initStripe, 200);
-    } else {
-        $('.stripe-payment-intents-form').each(function () {
-            $container = $(this);
+  // Because this might get executed before Stripe is loaded.
+  if (typeof Stripe === 'undefined') {
+    setTimeout(initStripe, 200);
+  } else {
+    $('.stripe-payment-intents-form').each(function () {
+      $container = $(this);
 
-            var handlerInstance = new PaymentIntents(
-                $container.data('publishablekey'),
-                $container
-            );
-            $container.data('handlerInstance', handlerInstance);
+      var handlerInstance = new PaymentIntents(
+        $container.data('publishablekey'),
+        $container
+      );
+      $container.data('handlerInstance', handlerInstance);
 
-            if ($container.data('scenario') == 'payment') {
-                handlerInstance.displayPaymentForm();
-            }
+      if ($container.data('scenario') == 'payment') {
+        handlerInstance.displayPaymentForm();
+      }
 
-            if ($container.data('scenario') == '3ds') {
-                handlerInstance.perform3dsAuthentication();
-            }
-        });
-    }
+      if ($container.data('scenario') == '3ds') {
+        handlerInstance.perform3dsAuthentication();
+      }
+    });
+  }
 }
 
 initStripe();


### PR DESCRIPTION
### Description

Fixes a non-nested array merge of `elementOptions`, and also includes default address and business data in the payment element.

Requires the cart/order being passed to the getPaymentFormHtml() method as an `order` param.

Fixes https://github.com/craftcms/commerce-stripe/issues/257
And likely also fixes https://github.com/craftcms/commerce-stripe/issues/263

