### PR TITLE
Expand payment method

### DIFF
--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -216,13 +216,17 @@ class PaymentIntents extends BaseGateway
     {
         $data = Json::decodeIfJson($transaction->response);
 
+        $paymentIntentOptions = [
+            'expand' => ['payment_method'],
+        ];
+        
         if ($data['object'] == 'payment_intent') {
-            $paymentIntent = $this->getStripeClient()->paymentIntents->retrieve($data['id']);
+            $paymentIntent = $this->getStripeClient()->paymentIntents->retrieve($data['id'], $paymentIntentOptions);
         } else {
             // Likely a checkout object
             $checkoutSession = $this->getStripeClient()->checkout->sessions->retrieve($data['id']);
             $paymentIntent = $checkoutSession['payment_intent'];
-            $paymentIntent = $this->getStripeClient()->paymentIntents->retrieve($paymentIntent);
+            $paymentIntent = $this->getStripeClient()->paymentIntents->retrieve($paymentIntent, $paymentIntentOptions);
         }
 
         return $this->createPaymentResponseFromApiResource($paymentIntent);


### PR DESCRIPTION
Expand payment method when retrieving the payment intent response on successful payment. Allows access to details on the specific card / payment wallet used. We had a requirement to identify when Google / Apple Pay have been used, this should make that possible without having to request seperatley via the stripe api.