### PR TITLE
Support legacy default_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where legacy default payment methods were not being set as default. ([#280](https://github.com/craftcms/commerce-stripe/pull/280))
+
 ## 4.1.0 - 2023-12-19
 
 - Stripe for Craft Commerce now requires Commerce 4.3.3 or later.

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -812,10 +812,12 @@ abstract class SubscriptionGateway extends Gateway
     {
         $stripeCustomer = $data['data']['object'];
 
-        // Set the primary payment source for the user if it has changed
-        if (isset($stripeCustomer['invoice_settings']['default_payment_method'])) {
-            $paymentMethodId = $stripeCustomer['invoice_settings']['default_payment_method'];
+        $defaultPaymentMethod = $stripeCustomer['invoice_settings']['default_payment_method']
+            ?? $stripeCustomer['default_source']
+            ?? null;
 
+        // Set the primary payment source for the user if it has changed
+        if ($defaultPaymentMethod) {
             $customer = StripePlugin::getInstance()->getCustomers()->getCustomerByReference($stripeCustomer['id'], $this->id);
             if (!$customer) {
                 return;
@@ -827,7 +829,7 @@ abstract class SubscriptionGateway extends Gateway
                 return;
             }
 
-            $paymentSource = CommercePlugin::getInstance()->getPaymentSources()->getPaymentSourceByTokenAndGatewayId($paymentMethodId, $this->id);
+            $paymentSource = CommercePlugin::getInstance()->getPaymentSources()->getPaymentSourceByTokenAndGatewayId($defaultPaymentMethod, $this->id);
             if (!$paymentSource) {
                 return;
             }


### PR DESCRIPTION
### Description
The stripe dashboard still uses the legacy sources API in the dashboard. Without this, setting a card as default for a customer in the Stripe dash will not be sync'd to Craft.