### PR TITLE
Add mutex to stripe payment method creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where legacy default payment methods were not being set as default. ([#280](https://github.com/craftcms/commerce-stripe/pull/280))
+- Fixed a bug that could cause duplicate payment sources to be created. ([#281](https://github.com/craftcms/commerce-stripe/pull/281))
 
 ## 4.1.0 - 2023-12-19
 

--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -446,9 +446,7 @@ abstract class Gateway extends BaseGateway
     }
 
     /**
-     * @return string
-     * @throws \Exception
-     * @since 2.3.1
+     * @inheritDoc
      */
     public function getTransactionHashFromWebhook(): ?string
     {
@@ -464,7 +462,13 @@ abstract class Gateway extends BaseGateway
 
         $transactionHash = ArrayHelper::getValue($data, 'data.object.metadata.transaction_reference');
         if (!$transactionHash || !is_string($transactionHash)) {
-            return null;
+            $transactionHash = null;
+        }
+
+        if(!$transactionHash) {
+            // Use the object ID as the unique ID of the stripe object for the transaction hash so we can enforce a mutex
+            // in \craft\commerce\services\Webhooks::processWebhook() which call this method.
+            $transactionHash = ArrayHelper::getValue($data, 'data.object.id');
         }
 
         return $transactionHash;

--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -465,7 +465,7 @@ abstract class Gateway extends BaseGateway
             $transactionHash = null;
         }
 
-        if(!$transactionHash) {
+        if (!$transactionHash) {
             // Use the object ID as the unique ID of the stripe object for the transaction hash so we can enforce a mutex
             // in \craft\commerce\services\Webhooks::processWebhook() which call this method.
             $transactionHash = ArrayHelper::getValue($data, 'data.object.id');

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -42,7 +42,6 @@ use Stripe\Product as StripeProduct;
 use Stripe\Refund;
 use Stripe\SubscriptionItem;
 use Throwable;
-use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use function count;
 
@@ -738,7 +737,7 @@ abstract class SubscriptionGateway extends Gateway
             $paymentSource->customerId = $user->id;
             $paymentSource->response = Json::encode($stripePaymentMethod);
 
-            if(!$paymentSource->id || $paymentSource->description == '') {
+            if (!$paymentSource->id || $paymentSource->description == '') {
                 $description = 'Stripe payment source';
 
                 if ($stripePaymentMethod['type'] === 'card') {

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -19,7 +19,6 @@ use craft\commerce\models\subscriptions\CancelSubscriptionForm as BaseCancelSubs
 use craft\commerce\models\subscriptions\SubscriptionForm as BaseSubscriptionForm;
 use craft\commerce\models\subscriptions\SubscriptionPayment;
 use craft\commerce\models\subscriptions\SwitchPlansForm;
-use craft\commerce\models\Transaction;
 use craft\commerce\Plugin;
 use craft\commerce\Plugin as CommercePlugin;
 use craft\commerce\records\Transaction as TransactionRecord;

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -719,6 +719,8 @@ abstract class SubscriptionGateway extends Gateway
             }
 
             $user = Craft::$app->getUsers()->getUserById($customer->userId);
+
+            // Ensure customer actually exists in Stripe
             $stripeCustomer = $this->getStripeClient()->customers->retrieve($stripePaymentMethod['customer']);
 
             if (!$stripeCustomer) {
@@ -737,7 +739,7 @@ abstract class SubscriptionGateway extends Gateway
             $paymentSource->customerId = $user->id;
             $paymentSource->response = Json::encode($stripePaymentMethod);
 
-            if (!$paymentSource->id || $paymentSource->description == '') {
+            if (!$paymentSource->id || !$paymentSource->description) {
                 $description = 'Stripe payment source';
 
                 if ($stripePaymentMethod['type'] === 'card') {

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -333,8 +333,7 @@ class PaymentIntents extends BaseGateway
         try {
             $lockName = "commerceTransaction:{$sourceData->paymentMethodId}";
 
-            // TODO: get int from stripe timeout
-            if (!Craft::$app->getMutex()->acquire($lockName, 5)) {
+            if (!Craft::$app->getMutex()->acquire($lockName, 15)) {
                 throw new Exception("Unable to acquire mutex lock: $lockName");
             }
 

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -331,7 +331,7 @@ class PaymentIntents extends BaseGateway
 
         /** @var PaymentIntentForm $sourceData */
         try {
-            $lockName = "stripePaymentMethod:{$sourceData->paymentMethodId}";
+            $lockName = "commerceTransaction:{$sourceData->paymentMethodId}";
 
             // TODO: get int from stripe timeout
             if (!Craft::$app->getMutex()->acquire($lockName, 5)) {

--- a/src/services/PaymentMethods.php
+++ b/src/services/PaymentMethods.php
@@ -45,7 +45,7 @@ class PaymentMethods
             foreach ($stripePaymentMethods as $stripePaymentMethod) {
                 $lockName = "commerceTransaction:{$stripePaymentMethod['id']}";
 
-                if (!Craft::$app->getMutex()->acquire($lockName, 5)) {
+                if (!Craft::$app->getMutex()->acquire($lockName, 15)) {
                     throw new Exception("Unable to acquire mutex lock: $lockName");
                 }
 

--- a/src/services/PaymentMethods.php
+++ b/src/services/PaymentMethods.php
@@ -7,12 +7,13 @@
 
 namespace craft\commerce\stripe\services;
 
+use Craft;
 use craft\commerce\events\UpdatePrimaryPaymentSourceEvent;
 use craft\commerce\Plugin as CommercePlugin;
 use craft\commerce\stripe\base\Gateway;
 use craft\commerce\stripe\base\SubscriptionGateway;
 use craft\commerce\stripe\Plugin;
-use Craft;
+use Exception;
 
 /**
  * Payment sources service.
@@ -42,7 +43,6 @@ class PaymentMethods
             );
 
             foreach ($stripePaymentMethods as $stripePaymentMethod) {
-
                 $lockName = "commerceTransaction:{$stripePaymentMethod['id']}";
 
                 if (!Craft::$app->getMutex()->acquire($lockName, 5)) {


### PR DESCRIPTION
Worked through this with @nfourtythree…

Without a mutex, when creating a payment source, the webhook for `payment_method.attach` can come in _before_ the payment source has been created, resulting in 2 payment sources, with the same token.


## Questions for discussion

#### Unique `commerce_paymentsources.token`?

We need the mutex to cover this, but also begs the question, should it even be possible for `commerce_paymentsources.token` to be non-unique? I guess other gateways might not have unique identifier tokens?

#### Unnecessary saves

Even with the mutex, saving a payment source still results in the payment source getting saved a min of 3 times.
  - The original save/insert
  - `payment_method.attach` webhook
  - `payment_method.updated` webhook

It seems like we could be more judicious about bailing early in `\craft\commerce\stripe\base\SubscriptionGateway::handlePaymentMethodUpdated` to cut that down. Eg, if an existing payment source is found, and this is a `payment_method.attach` event, we can probably just bail and not save?

Furthermore, with the webhook will currently always overwrite the description, which you may not want.

#### Mutex timeout

Right now we have a timeout of 5 seconds when acquiring the mutex. It seems like that should be based on the Stripe webhook timeout, but I couldn't find that docuemented. From what I can guess, it is pretty quick, probably closer to 2 seconds.

#### Duplicate stripe events for "connect"

I don't know if this is a local dev problem only or not, but when using `stripe listen` [as prescribed](https://github.com/craftcms/commerce-stripe?tab=readme-ov-file#local-development), you'll end up with duplicate webhooks for everything (one for "account", one for "connect").