### PR TITLE
Allow access to instance of JS class on the HTML element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where legacy default payment methods were not being set as default. ([#280](https://github.com/craftcms/commerce-stripe/pull/280))
 - Fixed a bug that could cause duplicate payment sources to be created. ([#281](https://github.com/craftcms/commerce-stripe/pull/281))
+- Fixed a bug where it wasn’t possible to access the Stripe instance from JavaScript. ([#275](https://github.com/craftcms/commerce-stripe/issues/275))
 
 ## 4.1.0 - 2023-12-19
 

--- a/src/web/assets/elementsform/js/paymentForm.js
+++ b/src/web/assets/elementsform/js/paymentForm.js
@@ -298,7 +298,7 @@ function initStripe() {
           container.dataset.publishablekey,
           container
         );
-        container.dataset.handlerInstance = handlerInstance;
+        container.handlerInstance = handlerInstance;
         handlerInstance.handle();
       });
   }


### PR DESCRIPTION
### Description
Currently the JS is setting the instance of the `PaymentIntentsElements` class into a data property on the element. This results in a value of `[Object Object]` meaning it is unusable to a developer.

This PR updates the code to simply add the instance directly to a property on the DOM node (using [expando](https://developer.mozilla.org/en-US/docs/Glossary/Expando)).

Meaning you are now able to access the instance and do something like the following:

```js
document.querySelector('.stripe-payment-elements-form').handlerInstance.elements.update({
  appearance: {theme: 'night'}
});
```

### Related issues
#275 
