### PR TITLE
Payment methods options match Stripe settings when creating a payment source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where legacy default payment methods were not being set as default. ([#280](https://github.com/craftcms/commerce-stripe/pull/280))
 - Fixed a bug that could cause duplicate payment sources to be created. ([#281](https://github.com/craftcms/commerce-stripe/pull/281))
 - Fixed a bug where it wasn’t possible to access the Stripe instance from JavaScript. ([#275](https://github.com/craftcms/commerce-stripe/issues/275))
+- Fixed a bug where not all enabled payment methods were being shown when creating a payment source. ([#251](https://github.com/craftcms/commerce-stripe/issues/251))
 
 ## 4.1.0 - 2023-12-19
 

--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -672,7 +672,6 @@ abstract class Gateway extends BaseGateway
     {
         $defaults = [
             'usage' => 'off_session',
-            'payment_method_types' => ['card'],
         ];
 
         $params = array_merge($defaults, $params);

--- a/src/controllers/CustomersController.php
+++ b/src/controllers/CustomersController.php
@@ -128,7 +128,6 @@ class CustomersController extends BaseController
             $gateway = CommercePlugin::getInstance()->getGateways()->getGatewayById((int)$gatewayId);
             $setupIntent = [
                 'customer' => $customer->reference,
-                'payment_method_types' => ['bancontact', 'card', 'ideal'],
             ];
             return $this->asJson($gateway->createSetupIntent($setupIntent));
         } catch (Throwable $e) {

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -348,7 +348,11 @@ class PaymentIntents extends BaseGateway
                     $description = Craft::t('commerce-stripe', '{cardType} ending in ••••{last4}', ['cardType' => StringHelper::upperCaseFirst($card->brand), 'last4' => $card->last4]);
                     break;
                 default:
-                    $description = $paymentMethod->type;
+                    if (isset($paymentMethod->{$paymentMethod->type}, $paymentMethod->{$paymentMethod->type}->last4)) {
+                        $description = Craft::t('commerce-stripe', 'Payment method ending in ••••{last4}', ['last4' => $paymentMethod->{$paymentMethod->type}->last4]);
+                    } else {
+                        $description = $paymentMethod->type;
+                    }
             }
 
             // Make it the default in Stripe if its the only one for this gateway


### PR DESCRIPTION
### Description
The code was, currently, restricting the payment method types when creating a payment source. Although is possible to alter these using the `Gateway::EVENT_BUILD_SETUP_INTENT_REQUEST` event this was not intended behaviour.

Removing this restrictions means that the options shown to a user when creating a payment source will match those methods enabled in Stripe's dashboard. This also means it now works in the same way as when a customer is making payment on an order.

### Related issues
#251 
