### PR TITLE
Payment Amount & Currency change handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug that could cause duplicate payment sources to be created. ([#281](https://github.com/craftcms/commerce-stripe/pull/281))
 - Fixed a bug where it wasn’t possible to access the Stripe instance from JavaScript. ([#275](https://github.com/craftcms/commerce-stripe/issues/275))
 - Fixed a bug where not all enabled payment methods were being shown when creating a payment source. ([#251](https://github.com/craftcms/commerce-stripe/issues/251), ([#160](https://github.com/craftcms/commerce-stripe/pull/160)))
+- Fixed a bug where changing a partial payment amount wouldn’t update the payment intent. ([#279](https://github.com/craftcms/commerce-stripe/issues/279))
 
 ## 4.1.0 - 2023-12-19
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "prettier": "^2.7.1"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "check-prettier": "prettier --check .",
+    "fix-prettier": "prettier --write ."
   }
 }

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -152,12 +152,12 @@ class PaymentIntents extends BaseGateway
                     'type' => 'tabs',
                 ],
             ],
+            'hiddenClass' => 'hidden',
             'submitButtonClasses' => '',
             'errorMessageClasses' => '',
             'submitButtonText' => Craft::t('commerce', 'Pay'),
             'processingButtonText' => Craft::t('commerce', 'Processing…'),
             'paymentFormType' => self::PAYMENT_FORM_TYPE_ELEMENTS,
-
         ];
 
         /** @var ?Order $order */

--- a/src/templates/paymentForms/elementsForm.twig
+++ b/src/templates/paymentForms/elementsForm.twig
@@ -13,8 +13,8 @@
      data-client-secret="{{ clientSecret }}"
      data-client-scenario="{{ scenario }}"
      data-processing-button-text="{{ processingButtonText }}"
+     data-hidden-class="{{ hiddenClass }}"
 >
-
     <div class="hidden stripe-error-message {{ errorMessageClasses }}">
         {# Error messages are displayed to your customers, here. #}
     </div>

--- a/src/web/assets/elementsform/js/paymentForm.js
+++ b/src/web/assets/elementsform/js/paymentForm.js
@@ -7,6 +7,11 @@ class PaymentIntentsElements {
     this.scenario = this.container.dataset.clientScenario;
     this.completeActionUrl = this.container.dataset.completePaymentActionUrl;
     this.processingButtonText = this.container.dataset.processingButtonText;
+    this.hiddenClass = this.container.dataset.hiddenClass;
+    this.$submitButton = this.container.querySelector('.stripe-payment-elements-submit-button');
+    this.$savePaymentSourceField = this.container.closest('form').querySelector('input[name="savePaymentSource"]');
+    this.$paymentAmountField = this.container.closest('form').querySelector('[name="paymentAmount"]');
+    this.$paymentCurrencyField = this.container.closest('form').querySelector('[name="paymentCurrency"]');
   }
 
   getFormData() {
@@ -14,9 +19,9 @@ class PaymentIntentsElements {
   }
 
   showErrorMessage(message) {
-    this.container.classList.remove('hidden');
+    this.container.classList.remove(this.hiddenClass);
     const errorMessage = this.container.querySelector('.stripe-error-message');
-    errorMessage.classList.remove('hidden');
+    errorMessage.classList.remove(this.hiddenClass);
     errorMessage.innerText = message;
   }
 
@@ -64,9 +69,7 @@ class PaymentIntentsElements {
     this.showErrorMessage(
       'Can not use the Stripe payment form to subscribe. Please create a payment source first.'
     );
-    this.container
-      .querySelector('.stripe-payment-elements-submit-button')
-      .classList.add('hidden');
+    this.$submitButton.classList.add(this.hiddenClass);
   }
 
   setupIntentFlow() {
@@ -106,17 +109,12 @@ class PaymentIntentsElements {
 
         this.createStripeElementsForm(options);
 
-        this.container
-          .querySelector('.stripe-payment-elements-submit-button')
+        this.$submitButton
           .addEventListener('click', async (event) => {
             event.preventDefault();
 
-            const submitText = this.container.querySelector(
-              '.stripe-payment-elements-submit-button'
-            ).innerText;
-            this.container.querySelector(
-              '.stripe-payment-elements-submit-button'
-            ).innerText = this.processingButtonText;
+            const submitText = this.$submitButton.innerText;
+            this.$submitButton.innerText = this.processingButtonText;
 
             const elements = this.elements;
             const form = this.getFormData();
@@ -137,9 +135,7 @@ class PaymentIntentsElements {
               .then((result) => {
                 if (result.error) {
                   this.showErrorMessage(result.error.message);
-                  this.container.querySelector(
-                    '.stripe-payment-elements-submit-button'
-                  ).innerText = submitText;
+                  this.$submitButton.innerText = submitText;
                 }
               });
           });
@@ -147,6 +143,22 @@ class PaymentIntentsElements {
   }
 
   cartPaymentFlow() {
+    if (this.$paymentAmountField) {
+      this.$paymentAmountField.addEventListener('change', (event) => {
+        this._callPayAction();
+      });
+    }
+
+    if (this.$paymentCurrencyField) {
+      this.$paymentCurrencyField.addEventListener('change', (event) => {
+        this._callPayAction();
+      });
+    }
+
+    this._callPayAction();
+  }
+
+  _callPayAction() {
     const form = this.getFormData();
     let responseError = false;
 
@@ -165,7 +177,7 @@ class PaymentIntentsElements {
       })
       .then((json) => {
         if (responseError) {
-          this.container.classList.add('hidden');
+          this.container.classList.add(this.hiddenClass);
           this.showErrorMessage(json.message);
           return;
         }
@@ -210,13 +222,14 @@ class PaymentIntentsElements {
           .closest('form')
           .querySelector('input[name="savePaymentSource"]');
 
-        if (savePaymentSourceCheckbox) {
-          savePaymentSourceCheckbox.addEventListener(
+        if (this.$savePaymentSourceField) {
+          this.$savePaymentSourceField.removeEventListener('click', function () {});
+          this.$savePaymentSourceField.addEventListener(
             'click',
             function () {
               updatePaymentIntentForm.append(
                 'paymentIntent[setup_future_usage]',
-                savePaymentSourceCheckbox.checked ? '1' : '0'
+                this.$savePaymentSourceField.checked ? '1' : '0'
               );
 
               fetch(window.location.href, {
@@ -240,17 +253,12 @@ class PaymentIntentsElements {
           );
         }
 
-        this.container
-          .querySelector('.stripe-payment-elements-submit-button')
+        this.$submitButton
           .addEventListener('click', async (event) => {
             event.preventDefault();
 
-            const submitText = this.container.querySelector(
-              '.stripe-payment-elements-submit-button'
-            ).innerText;
-            this.container.querySelector(
-              '.stripe-payment-elements-submit-button'
-            ).innerText = this.processingButtonText;
+            const submitText = this.$submitButton.innerText;
+            this.$submitButton.innerText = this.processingButtonText;
 
             const elements = this.elements;
             const {error} = await this.stripeInstance.confirmPayment({
@@ -259,9 +267,7 @@ class PaymentIntentsElements {
                 return_url: this.completeActionUrl,
               },
             });
-            this.container.querySelector(
-              '.stripe-payment-elements-submit-button'
-            ).innerText = submitText;
+            this.$submitButton.innerText = submitText;
             this.showErrorMessage(error.message);
           });
       });

--- a/src/web/assets/elementsform/js/paymentForm.js
+++ b/src/web/assets/elementsform/js/paymentForm.js
@@ -8,10 +8,18 @@ class PaymentIntentsElements {
     this.completeActionUrl = this.container.dataset.completePaymentActionUrl;
     this.processingButtonText = this.container.dataset.processingButtonText;
     this.hiddenClass = this.container.dataset.hiddenClass;
-    this.$submitButton = this.container.querySelector('.stripe-payment-elements-submit-button');
-    this.$savePaymentSourceField = this.container.closest('form').querySelector('input[name="savePaymentSource"]');
-    this.$paymentAmountField = this.container.closest('form').querySelector('[name="paymentAmount"]');
-    this.$paymentCurrencyField = this.container.closest('form').querySelector('[name="paymentCurrency"]');
+    this.$submitButton = this.container.querySelector(
+      '.stripe-payment-elements-submit-button'
+    );
+    this.$savePaymentSourceField = this.container
+      .closest('form')
+      .querySelector('input[name="savePaymentSource"]');
+    this.$paymentAmountField = this.container
+      .closest('form')
+      .querySelector('[name="paymentAmount"]');
+    this.$paymentCurrencyField = this.container
+      .closest('form')
+      .querySelector('[name="paymentCurrency"]');
   }
 
   getFormData() {
@@ -109,36 +117,35 @@ class PaymentIntentsElements {
 
         this.createStripeElementsForm(options);
 
-        this.$submitButton
-          .addEventListener('click', async (event) => {
-            event.preventDefault();
+        this.$submitButton.addEventListener('click', async (event) => {
+          event.preventDefault();
 
-            const submitText = this.$submitButton.innerText;
-            this.$submitButton.innerText = this.processingButtonText;
+          const submitText = this.$submitButton.innerText;
+          this.$submitButton.innerText = this.processingButtonText;
 
-            const elements = this.elements;
-            const form = this.getFormData();
-            const formDataArray = [...form.entries()];
-            const params = formDataArray
-              .map(
-                (x) => `${encodeURIComponent(x[0])}=${encodeURIComponent(x[1])}`
-              )
-              .join('&');
+          const elements = this.elements;
+          const form = this.getFormData();
+          const formDataArray = [...form.entries()];
+          const params = formDataArray
+            .map(
+              (x) => `${encodeURIComponent(x[0])}=${encodeURIComponent(x[1])}`
+            )
+            .join('&');
 
-            this.stripeInstance
-              .confirmSetup({
-                elements,
-                confirmParams: {
-                  return_url: `${this.container.dataset.confirmSetupIntentUrl}&${params}`,
-                },
-              })
-              .then((result) => {
-                if (result.error) {
-                  this.showErrorMessage(result.error.message);
-                  this.$submitButton.innerText = submitText;
-                }
-              });
-          });
+          this.stripeInstance
+            .confirmSetup({
+              elements,
+              confirmParams: {
+                return_url: `${this.container.dataset.confirmSetupIntentUrl}&${params}`,
+              },
+            })
+            .then((result) => {
+              if (result.error) {
+                this.showErrorMessage(result.error.message);
+                this.$submitButton.innerText = submitText;
+              }
+            });
+        });
       });
   }
 
@@ -223,7 +230,10 @@ class PaymentIntentsElements {
           .querySelector('input[name="savePaymentSource"]');
 
         if (this.$savePaymentSourceField) {
-          this.$savePaymentSourceField.removeEventListener('click', function () {});
+          this.$savePaymentSourceField.removeEventListener(
+            'click',
+            function () {}
+          );
           this.$savePaymentSourceField.addEventListener(
             'click',
             function () {
@@ -253,23 +263,22 @@ class PaymentIntentsElements {
           );
         }
 
-        this.$submitButton
-          .addEventListener('click', async (event) => {
-            event.preventDefault();
+        this.$submitButton.addEventListener('click', async (event) => {
+          event.preventDefault();
 
-            const submitText = this.$submitButton.innerText;
-            this.$submitButton.innerText = this.processingButtonText;
+          const submitText = this.$submitButton.innerText;
+          this.$submitButton.innerText = this.processingButtonText;
 
-            const elements = this.elements;
-            const {error} = await this.stripeInstance.confirmPayment({
-              elements,
-              confirmParams: {
-                return_url: this.completeActionUrl,
-              },
-            });
-            this.$submitButton.innerText = submitText;
-            this.showErrorMessage(error.message);
+          const elements = this.elements;
+          const {error} = await this.stripeInstance.confirmPayment({
+            elements,
+            confirmParams: {
+              return_url: this.completeActionUrl,
+            },
           });
+          this.$submitButton.innerText = submitText;
+          this.showErrorMessage(error.message);
+        });
       });
   }
 


### PR DESCRIPTION
### Description
Currently, everything works as expected if the payment amount and currency as present in the form on page load. This is because the payment is created initially on load using the data in the form.

This PR includes code to watch these form values and create a new transaction and payment intent if those value change. Meaning if you have a payment currency or payment amount dropdown on the payment form, selecting different values will now trigger the change.

### Related issues
#279
