### PR TITLE
Fixed use of hidden class on elements

### DIFF
--- a/src/templates/paymentForms/elementsForm.twig
+++ b/src/templates/paymentForms/elementsForm.twig
@@ -2,7 +2,7 @@
     window.csrfTokenName = "{{ craft.app.config.general.csrfTokenName }}";
     window.csrfTokenValue = "{{ craft.app.request.csrfToken }}";
 </script>
-<div class="stripe-payment-elements-form hidden"
+<div class="stripe-payment-elements-form {{ hiddenClass }}"
      data-publishablekey="{{ gateway.getPublishableKey() }}"
      data-complete-payment-action-url="{{ actionUrl('commerce/payments/complete-payment') }}"
      data-confirm-setup-intent-url="{{ actionUrl('commerce-stripe/customers/confirm-setup-intent') }}"
@@ -15,7 +15,7 @@
      data-processing-button-text="{{ processingButtonText }}"
      data-hidden-class="{{ hiddenClass }}"
 >
-    <div class="hidden stripe-error-message {{ errorMessageClasses }}">
+    <div class="{{ hiddenClass }} stripe-error-message {{ errorMessageClasses }}">
         {# Error messages are displayed to your customers, here. #}
     </div>
     <div class="stripe-payment-form">

--- a/src/web/assets/elementsform/js/paymentForm.js
+++ b/src/web/assets/elementsform/js/paymentForm.js
@@ -53,7 +53,7 @@ class PaymentIntentsElements {
     paymentElement.on('change', layoutChangeHandler);
 
     // Show the container:
-    this.container.classList.remove('hidden');
+    this.container.classList.remove(this.hiddenClass);
   }
 
   async requiresActionFlow() {


### PR DESCRIPTION
On some elements there is an hard coded `hidden` class instead of use the `hiddenClass` param.

