### PR TITLE
fix: Fix a potential rounding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where floating point rounding precision could cause payments/refunds to fail. ([#296](https://github.com/craftcms/commerce-stripe/pull/296))
+
 ## 4.1.2 - 2024-03-25
 
 - Fixed a bug where redirects could break when adding a new payment source. ([#259](https://github.com/craftcms/commerce-stripe/issues/259), [#289](https://github.com/craftcms/commerce-stripe/issues/289))

--- a/src/gateways/PaymentIntents.php
+++ b/src/gateways/PaymentIntents.php
@@ -287,7 +287,7 @@ class PaymentIntents extends BaseGateway
             try {
                 $request = [
                     'charge' => $transaction->reference,
-                    'amount' => $transaction->paymentAmount * (10 ** $currency->minorUnit),
+                    'amount' => (int) bcmul($transaction->paymentAmount, 10 ** $currency->minorUnit),
                 ];
                 $refund = $this->getStripeClient()->refunds->create($request);
 
@@ -303,7 +303,7 @@ class PaymentIntents extends BaseGateway
             if ($stripePaymentIntent->status == 'succeeded') {
                 $refund = $this->getStripeClient()->refunds->create([
                     'payment_intent' => $stripePaymentIntent->id,
-                    'amount' => $transaction->paymentAmount * (10 ** $currency->minorUnit),
+                    'amount' => (int) bcmul($transaction->paymentAmount, 10 ** $currency->minorUnit),
                 ]);
 
                 return $this->createPaymentResponseFromApiResource($refund);
@@ -638,7 +638,7 @@ class PaymentIntents extends BaseGateway
         }
 
         // Normalized amount for Stripe into minor units
-        $amount = $transaction->paymentAmount * (10 ** $currency->minorUnit);
+        $amount = (int) bcmul($transaction->paymentAmount, 10 ** $currency->minorUnit);
 
         /** @var PaymentIntentForm $form */
         if ($form->paymentFormType == self::PAYMENT_FORM_TYPE_CHECKOUT) {


### PR DESCRIPTION
### Description

There's a potential rounding error when multiplying floating point numbers. This PR covers three cases where the gateway would perform a potentially unsafe multiplication and replaces them with a call to `bcmul`. `bcmul` is part of the `bcmath` extension that is required by Craft 4.x.