### PR TITLE
[5.x] Fix checkout session webhook completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where checkout session completion would not mark transactions as successful from webhooks. ([]())
 - Fixed the performance of loading plans in the control panel. ([#322](https://github.com/craftcms/commerce-stripe/issues/322))
 - Fixed a PHP error that could occur when handling a webhook request.
 - Fixed a bug where choosing bank transfer as a payment method wouldn’t complete an order. ([#315](https://github.com/craftcms/commerce-stripe/issues/315))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where checkout session completion would not mark transactions as successful from webhooks. ([]())
+- Fixed a bug where checkout session completion would not mark transactions as successful from webhooks. ([#318](https://github.com/craftcms/commerce-stripe/issues/318))
 - Fixed the performance of loading plans in the control panel. ([#322](https://github.com/craftcms/commerce-stripe/issues/322))
 - Fixed a PHP error that could occur when handling a webhook request.
 - Fixed a bug where choosing bank transfer as a payment method wouldn’t complete an order. ([#315](https://github.com/craftcms/commerce-stripe/issues/315))

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -537,7 +537,7 @@ abstract class SubscriptionGateway extends Gateway
                 'payment_intent' => $paymentIntent['id'],
             ]);
 
-            if($session = $sessions->data[0] ?? null)
+            if($session = $sessions->data[0] ?? null) {
                 $transaction = Plugin::getInstance()->getTransactions()->getTransactionByReference($session['id']);
                 $error = '';
                 Plugin::getInstance()->getPayments()->completePayment($transaction, $error);

--- a/src/base/SubscriptionGateway.php
+++ b/src/base/SubscriptionGateway.php
@@ -531,6 +531,19 @@ abstract class SubscriptionGateway extends Gateway
     {
         $paymentIntent = $data['data']['object'];
         if ($paymentIntent['object'] === 'payment_intent') {
+
+            // Before we treat this as a normal payment intent, lets see if it was checkout session payment intent
+            $sessions = $this->getStripeClient()->checkout->sessions->all([
+                'payment_intent' => $paymentIntent['id'],
+            ]);
+
+            if($session = $sessions->data[0] ?? null)
+                $transaction = Plugin::getInstance()->getTransactions()->getTransactionByReference($session['id']);
+                $error = '';
+                Plugin::getInstance()->getPayments()->completePayment($transaction, $error);
+                return;
+            }
+
             $transaction = Plugin::getInstance()->getTransactions()->getTransactionByReference($paymentIntent['id']);
 
             if (!$transaction?->id) {


### PR DESCRIPTION
### Description

webhooks couldn't complete checkout sessions previously

### Related issues

https://github.com/craftcms/commerce-stripe/issues/318